### PR TITLE
#5 Update travis.yml to reinstate codecov uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ install: "pip install -r requirements.txt"
 # # command to run tests
 script:
   - coverage run pymjq/test.py
-  - coverage combine
-#  - coverage report --omit '/home/travis/virtualenv/python2.7.9/*'
+
 after_success: codecov


### PR DESCRIPTION
Coverage combine seems to null out the collected data.
By removing it data gets uploaded to codecov which _should_ fix the badge.
e.g. https://codecov.io/gh/discogs/pymongo-job-queue/pull/7/graph/badge.svg
